### PR TITLE
Add view for retrieving registrations

### DIFF
--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -386,24 +386,26 @@ class TestRegistrationAPI(AuthenticatedAPITestCase):
         registration = self.make_registration_adminuser()
         # Execute
         response = self.adminclient.get(
-            '/api/v1/registration/%s/' % registration.id,
+            '/api/v1/registrations/%s/' % registration.id,
             content_type='application/json')
         # Check
-        # Currently only posts are allowed
-        self.assertEqual(response.status_code,
-                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["stage"], "prebirth")
+        self.assertEqual(response.data["data"]["test_adminuser_reg_key"],
+                         "test_adminuser_reg_value")
 
     def test_get_registration_normaluser(self):
         # Setup
         registration = self.make_registration_normaluser()
         # Execute
         response = self.normalclient.get(
-            '/api/v1/registration/%s/' % registration.id,
+            '/api/v1/registrations/%s/' % registration.id,
             content_type='application/json')
         # Check
-        # Currently only posts are allowed
-        self.assertEqual(response.status_code,
-                         status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["stage"], "prebirth")
+        self.assertEqual(response.data["data"]["test_normaluser_reg_key"],
+                         "test_normaluser_reg_value")
 
     def test_create_registration_adminuser(self):
         # Setup

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -474,6 +474,149 @@ class TestRegistrationAPI(AuthenticatedAPITestCase):
         self.assertEqual(d.validated, False)  # Should ignore True post_data
         self.assertEqual(d.data, {"test_key1": "test_value1"})
 
+    def test_list_registrations(self):
+        # Setup
+        registration1 = self.make_registration_normaluser()
+        registration2 = self.make_registration_adminuser()
+        # Execute
+        response = self.normalclient.get(
+            '/api/v1/registrations/', content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        result1, result2 = response.data["results"]
+        self.assertEqual(result1["id"], str(registration1.id))
+        self.assertEqual(result2["id"], str(registration2.id))
+
+    def make_different_registrations(self):
+        self.make_source_adminuser()
+        registration1_data = {
+            "stage": "prebirth",
+            "mother_id": "mother01-63e2-4acc-9b94-26663b9bc267",
+            "data": REG_DATA["hw_pre_id_hoh"].copy(),
+            "source": self.make_source_adminuser(),
+            "validated": True
+        }
+        registration1 = Registration.objects.create(**registration1_data)
+        registration2_data = {
+            "stage": "postbirth",
+            "mother_id": "mother02-63e2-4acc-9b94-26663b9bc267",
+            "data": REG_DATA["hw_pre_id_hoh"].copy(),
+            "source": self.make_source_normaluser(),
+            "validated": False
+        }
+        registration2 = Registration.objects.create(**registration2_data)
+
+        return (registration1, registration2)
+
+    def test_filter_registration_mother_id(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?mother_id=%s' % registration1.mother_id,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(registration1.id))
+
+    def test_filter_registration_stage(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?stage=%s' % registration2.stage,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(registration2.id))
+
+    def test_filter_registration_validated(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?validated=%s' % registration1.validated,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(registration1.id))
+
+    def test_filter_registration_source(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?source=%s' % registration2.source.id,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(registration2.id))
+
+    def test_filter_registration_created_after(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # While the '+00:00' is valid according to ISO 8601, the version of
+        # django-filter we are using does not support it
+        date_string = registration2.created_at.isoformat().replace(
+            "+00:00", "Z")
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?created_after=%s' % date_string,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(registration2.id))
+
+    def test_filter_registration_created_before(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # While the '+00:00' is valid according to ISO 8601, the version of
+        # django-filter we are using does not support it
+        date_string = registration1.created_at.isoformat().replace(
+            "+00:00", "Z")
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?created_before=%s' % date_string,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(registration1.id))
+
+    def test_filter_registration_no_matches(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?mother_id=test_id',
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+
+    def test_filter_registration_unknown_filter(self):
+        # Setup
+        registration1, registration2 = self.make_different_registrations()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/registrations/?something=test_id',
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
 
 class TestFieldValidation(AuthenticatedAPITestCase):
 

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -7,6 +7,7 @@ router.register(r'user', views.UserViewSet)
 router.register(r'group', views.GroupViewSet)
 router.register(r'source', views.SourceViewSet)
 router.register(r'webhook', views.HookViewSet)
+router.register(r'registrations', views.RegistrationGetViewSet)
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browseable API.

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -78,4 +78,4 @@ class RegistrationGetViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated,)
     queryset = Registration.objects.all()
     serializer_class = RegistrationSerializer
-    filter_fields = ('mother_id',)
+    filter_fields = ('stage', 'mother_id', 'validated', 'source', 'created_at')

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -1,6 +1,7 @@
+import django_filters
 from django.contrib.auth.models import User, Group
 from rest_hooks.models import Hook
-from rest_framework import viewsets, mixins, generics
+from rest_framework import viewsets, mixins, generics, filters
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 
 from .models import Source, Registration
@@ -71,6 +72,20 @@ class RegistrationPost(mixins.CreateModelMixin, generics.GenericAPIView):
     #     serializer.save(updated_by=self.request.user)
 
 
+class RegistrationFilter(filters.FilterSet):
+    """Filter for registrations created, using ISO 8601 formatted dates"""
+    created_before = django_filters.IsoDateTimeFilter(name="created_at",
+                                                      lookup_type="lte")
+    created_after = django_filters.IsoDateTimeFilter(name="created_at",
+                                                     lookup_type="gte")
+
+    class Meta:
+        model = Registration
+        ('stage', 'mother_id', 'validated', 'source', 'created_at')
+        fields = ['stage', 'mother_id', 'validated', 'source',
+                  'created_before', 'created_after']
+
+
 class RegistrationGetViewSet(viewsets.ReadOnlyModelViewSet):
     """
     API endpoint that allows Registrations to be viewed.
@@ -78,4 +93,4 @@ class RegistrationGetViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated,)
     queryset = Registration.objects.all()
     serializer_class = RegistrationSerializer
-    filter_fields = ('stage', 'mother_id', 'validated', 'source', 'created_at')
+    filter_class = RegistrationFilter

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -69,3 +69,13 @@ class RegistrationPost(mixins.CreateModelMixin, generics.GenericAPIView):
 
     # def perform_update(self, serializer):
     #     serializer.save(updated_by=self.request.user)
+
+
+class RegistrationGetViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows Registrations to be viewed.
+    """
+    permission_classes = (IsAuthenticated,)
+    queryset = Registration.objects.all()
+    serializer_class = RegistrationSerializer
+    filter_fields = ('mother_id',)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'six==1.10.0',
         'django-rest-hooks==1.3.1',
         'requests==2.9.1',
+        'django-filter==0.12.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Add an API endpoint for retrieving registrations. Requirements:
Allows filtering by fields, especially mother_id (@imsickofmaps I presume this is the uuid that we can expect casepro to have?).
Returns details of related objects
