### PR TITLE
Add api end point for generating access token

### DIFF
--- a/familyconnect_registration/urls.py
+++ b/familyconnect_registration/urls.py
@@ -29,9 +29,9 @@ urlpatterns = [
         include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/token-auth/', rest_framework.authtoken.views.obtain_auth_token),
     url(r'^api/metrics/', views.MetricsView.as_view()),
-    url(r'^api/v1/', include(router.urls)),
     url(r'^', include('registrations.urls')),
     url(r'^', include('changes.urls')),
     url(r'^', include('uniqueids.urls')),
     url(r'^', include('locations.urls')),
+    url(r'^api/v1/', include(router.urls)),
 ]

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -16,6 +16,10 @@ class GroupSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('url', 'name')
 
 
+class CreateUserSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1406,7 +1406,6 @@ class TestUserCreation(AuthenticatedAPITestCase):
         user_request = {"email": "test@example.org"}
         # Execute
         request = self.adminclient.post('/api/v1/user/token/', user_request)
-        print request
         token = request.json().get('token', None)
         # Check
         self.assertIsNotNone(

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1399,6 +1399,72 @@ class TestSendLocationRemindersTask(AuthenticatedAPITestCase):
             'mother03-63e2-4acc-9b94-26663b9bc267', 'cgg_UG')
 
 
+class TestUserCreation(AuthenticatedAPITestCase):
+
+    def test_create_user_and_token(self):
+        # Setup
+        user_request = {"email": "test@example.org"}
+        # Execute
+        request = self.adminclient.post('/api/v1/user/token/', user_request)
+        print request
+        token = request.json().get('token', None)
+        # Check
+        self.assertIsNotNone(
+            token, "Could not receive authentication token on post.")
+        self.assertEqual(
+            request.status_code, 201,
+            "Status code on /api/v1/user/token/ was %s (should be 201)."
+            % request.status_code)
+
+    def test_create_user_and_token_fail_nonadmin(self):
+        # Setup
+        user_request = {"email": "test@example.org"}
+        # Execute
+        request = self.normalclient.post('/api/v1/user/token/', user_request)
+        error = request.json().get('detail', None)
+        # Check
+        self.assertIsNotNone(
+            error, "Could not receive error on post.")
+        self.assertEqual(
+            error, "You do not have permission to perform this action.",
+            "Error message was unexpected: %s."
+            % error)
+
+    def test_create_user_and_token_not_created(self):
+        # Setup
+        user_request = {"email": "test@example.org"}
+        # Execute
+        request = self.adminclient.post('/api/v1/user/token/', user_request)
+        token = request.json().get('token', None)
+        # And again, to get the same token
+        request2 = self.adminclient.post('/api/v1/user/token/', user_request)
+        token2 = request2.json().get('token', None)
+
+        # Check
+        self.assertEqual(
+            token, token2,
+            "Tokens are not equal, should be the same as not recreated.")
+
+    def test_create_user_new_token_nonadmin(self):
+        # Setup
+        user_request = {"email": "test@example.org"}
+        request = self.adminclient.post('/api/v1/user/token/', user_request)
+        token = request.json().get('token', None)
+        cleanclient = APIClient()
+        cleanclient.credentials(HTTP_AUTHORIZATION='Token %s' % token)
+        # Execute
+        request = cleanclient.post('/api/v1/user/token/', user_request)
+        error = request.json().get('detail', None)
+        # Check
+        # new user should not be admin
+        self.assertIsNotNone(
+            error, "Could not receive error on post.")
+        self.assertEqual(
+            error, "You do not have permission to perform this action.",
+            "Error message was unexpected: %s."
+            % error)
+
+
 class TestMetricsAPI(AuthenticatedAPITestCase):
 
     def test_metrics_read(self):

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -13,4 +13,6 @@ router.register(r'registrations', views.RegistrationGetViewSet)
 # Additionally, we include login URLs for the browseable API.
 urlpatterns = [
     url(r'^api/v1/registration/', views.RegistrationPost.as_view()),
+    url(r'^api/v1/user/token/$', views.UserView.as_view(),
+        name='create-user-token'),
 ]

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -1,15 +1,16 @@
 import django_filters
 from django.contrib.auth.models import User, Group
 from rest_hooks.models import Hook
-from rest_framework import viewsets, mixins, generics, filters
+from rest_framework import viewsets, mixins, generics, status, filters
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.authtoken.models import Token
 
 from .models import Source, Registration
 from .serializers import (UserSerializer, GroupSerializer,
                           SourceSerializer, RegistrationSerializer,
-                          HookSerializer)
+                          HookSerializer, CreateUserSerializer)
 from familyconnect_registration.utils import get_available_metrics
 # Uncomment line below if scheduled metrics are added
 # from .tasks import scheduled_metrics
@@ -45,6 +46,29 @@ class GroupViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated,)
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
+
+
+class UserView(APIView):
+    """ API endpoint that allows users creation and returns their token.
+    Only admin users can do this to avoid permissions escalation.
+    """
+    permission_classes = (IsAdminUser,)
+
+    def post(self, request):
+        '''Create a user and token, given an email. If user exists just
+        provide the token.'''
+        serializer = CreateUserSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        email = serializer.validated_data.get('email')
+        try:
+            user = User.objects.get(username=email)
+        except User.DoesNotExist:
+            user = User.objects.create_user(email, email=email)
+        token, created = Token.objects.get_or_create(user=user)
+
+        return Response(
+            status=status.HTTP_201_CREATED, data={'token': token.key})
 
 
 class SourceViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This endpoint will be used by the CI-Service to create access tokens for users using the CI.
Without it, users of the CI will not be able to view registrations.

This code is a copy of the implementation in https://github.com/praekelt/hellomama-registration/tree/develop/registrations