### PR TITLE
API endpoint for viewing and filtering changes

### DIFF
--- a/changes/tests.py
+++ b/changes/tests.py
@@ -360,6 +360,38 @@ class TestChangeAPI(AuthenticatedAPITestCase):
         self.assertEqual(d.data, {"test_key1": "test_value1"})
 
 
+class TestChangeListAPI(AuthenticatedAPITestCase):
+
+    def test_list_changes(self):
+        # Setup
+        change1 = self.make_change_adminuser()
+        change2 = self.make_change_normaluser()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/changes/',
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        result1, result2 = response.data["results"]
+        self.assertEqual(result1["id"], str(change1.id))
+        self.assertEqual(result2["id"], str(change2.id))
+
+    def test_list_changes_filtered(self):
+        # Setup
+        self.make_change_adminuser()
+        change2 = self.make_change_normaluser()
+        # Execute
+        response = self.adminclient.get(
+            '/api/v1/changes/?source=%s' % change2.source.id,
+            content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        result = response.data["results"][0]
+        self.assertEqual(result["id"], str(change2.id))
+
+
 class TestRegistrationCreation(AuthenticatedAPITestCase):
 
     def test_make_registration_mother(self):

--- a/changes/urls.py
+++ b/changes/urls.py
@@ -3,6 +3,7 @@ from rest_framework import routers
 from . import views
 
 router = routers.DefaultRouter()
+router.register(r'changes', views.ChangeGetViewSet)
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browseable API.

--- a/changes/views.py
+++ b/changes/views.py
@@ -1,5 +1,6 @@
+import django_filters
 from .models import Source, Change
-from rest_framework import mixins, generics
+from rest_framework import viewsets, mixins, generics, filters
 from rest_framework.permissions import IsAuthenticated
 from .serializers import ChangeSerializer
 
@@ -22,3 +23,27 @@ class ChangePost(mixins.CreateModelMixin, generics.GenericAPIView):
 
     # def perform_update(self, serializer):
     #     serializer.save(updated_by=self.request.user)
+
+
+class ChangeFilter(filters.FilterSet):
+    """Filter for changes created, using ISO 8601 formatted dates"""
+    created_before = django_filters.IsoDateTimeFilter(name="created_at",
+                                                      lookup_type="lte")
+    created_after = django_filters.IsoDateTimeFilter(name="created_at",
+                                                     lookup_type="gte")
+
+    class Meta:
+        model = Change
+        ('action', 'mother_id', 'validated', 'source', 'created_at')
+        fields = ['action', 'mother_id', 'validated', 'source',
+                  'created_before', 'created_after']
+
+
+class ChangeGetViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    API endpoint that allows Changes to be viewed.
+    """
+    permission_classes = (IsAuthenticated,)
+    queryset = Change.objects.all()
+    serializer_class = ChangeSerializer
+    filter_class = ChangeFilter


### PR DESCRIPTION
This endpoint will be used by the CI-Service to display changes to users using the CI.

This code is a copy of the implementation in https://github.com/praekelt/hellomama-registration/tree/develop/changes